### PR TITLE
feat: add initial implementation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   id-token: write # required for npm provenance
 
 env:
-  NODE_VER: 22.18
+  NODE_VER: 24.7
   CI: true
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release on NPM
+
+on:
+  release:
+    types: [published] # runs when a GitHub Release is published
+
+permissions:
+  contents: read
+  id-token: write # required for npm provenance
+
+env:
+  NODE_VER: 22.18
+  CI: true
+
+jobs:
+  publish:
+    name: Publish package from release tag
+    # Run only when tag is in the format `vX.Y.Z` produced by `npm version`
+    if: startsWith(github.event.release.tag_name, 'v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out the tag referenced by this release
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
+      - name: Setup Node.js and pnpm
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VER }}
+          cache: 'pnpm'
+          # This is required for `setup-node` to generate the registry URL into .npmrc
+          # See https://github.com/actions/setup-node/blob/5e2628c959b9ade56971c0afcebbe5332d44b398/action.yml#L17-L18
+          registry-url: 'https://registry.npmjs.org/'
+
+      - name: Verify tag matches package.json version
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "v$PKG_VERSION" != "$TAG" ]; then
+            echo "::error ::Tag ($TAG) does not match package.json version (v$PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install deps
+        run: |
+          pnpm --version
+          pnpm install --frozen-lockfile
+
+      # Note: no build step because npm publish would run `prepack` script which builds the module
+
+      - name: Publish to npm with provenance
+        env:
+          # Environment variable used by `setup-node` action
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+
+          # Stable release (vX.Y.Z)
+          if echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+            npm publish --provenance --access public
+
+          # Pre-release (vX.Y.Z-*)
+          elif echo "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            npm publish --provenance --access public --tag next
+
+          else
+            echo "Not a valid release tag ($TAG), skipping publish."
+          fi
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# @sidebase/authjs-prisma-adapter
+
+A **type-compatible [NextAuth.js](https://next-auth.js.org/) Prisma adapter** for Prisma 6, designed for projects where the Prisma client is not located at `@prisma/client`.
+
+This solves the problem with the official [`@next-auth/prisma-adapter`](https://github.com/nextauthjs/next-auth/tree/main/packages/adapter-prisma), which hardcodes an import from `@prisma/client`.
+In Nuxt or custom setups (e.g. when the client lives at `~/prisma/client`), that import path cannot be resolved and breaks builds.
+
+This adapter avoids the dependency on Prisma types and lets you use your own Prisma client instance.
+
+The adapter is primarily meant for use with [`@sidebase/nuxt-auth`](https://github.com/sidebase/nuxt-auth) module.
+
+## Installation
+
+```bash
+npm install @sidebase/authjs-prisma-adapter
+# or
+pnpm add @sidebase/authjs-prisma-adapter
+````
+
+## Usage
+
+```ts
+// server/api/auth/[...].ts
+import { PrismaAdapter } from '@sidebase/authjs-prisma-adapter'
+import { NuxtAuthHandler } from '#auth'
+
+// Import your Prisma client (can live anywhere in your project)
+import { prisma } from '~/prisma/client'
+
+export default NuxtAuthHandler({
+  adapter: PrismaAdapter(prisma),
+  // ... other configuration
+})
+```
+
+## Why not the official adapter?
+
+* The official `@next-auth/prisma-adapter` directly imports from `@prisma/client`.
+* In Nuxt or monorepo setups, Prisma 6 can be generated in a custom path (e.g. `~/prisma/client`).
+* That import fails, making the official adapter unusable.
+
+This adapter re-implements the same logic from [next-auth@4.21.1](https://github.com/nextauthjs/next-auth/blob/d69f311ddcc328d234c286ddef83f1d5934ea1fb/packages/adapter-prisma/src/index.ts), but without importing `@prisma/client`.
+
+## API
+
+```ts
+function PrismaAdapter(prisma: PrismaClient): Adapter
+```
+
+* **`prisma`**: Your own Prisma client instance.
+* Returns a NextAuth-compatible `Adapter`.
+
+## Compatibility
+
+* **prisma**: `^6.0.0`
+* **next-auth**: `4.21.1`
+
+## License
+
+MIT
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sidebase/authjs-prisma-adapter",
   "version": "1.0.0",
-  "description": "A Prisma 6 adapter for next-auth/authjs",
+  "description": "A next-auth/authjs type-compatible Prisma 6 adapter for the new `prisma-client`-provider",
   "keywords": [],
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@sidebase/authjs-prisma-adapter",
+  "version": "1.0.0",
+  "description": "A Prisma 6 adapter for next-auth/authjs",
+  "keywords": [],
+  "license": "MIT",
+  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc",
+    "prepack": "pnpm build"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.2"
+  },
+  "peerDependencies": {
+    "next-auth": "~4.21.1"
+  },
+  "packageManager": "pnpm@10.15.0+sha512.486ebc259d3e999a4e8691ce03b5cac4a71cbeca39372a9b762cb500cfdf0873e2cb16abe3d951b1ee2cf012503f027b98b6584e4df22524e0c7450d9ec7aa7b"
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,408 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      next-auth:
+        specifier: ~4.21.1
+        version: 4.21.1(next@13.5.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    devDependencies:
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.2
+
+packages:
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@next/env@13.5.11':
+    resolution: {integrity: sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg==}
+
+  '@next/swc-darwin-arm64@13.5.9':
+    resolution: {integrity: sha512-pVyd8/1y1l5atQRvOaLOvfbmRwefxLhqQOzYo/M7FQ5eaRwA1+wuCn7t39VwEgDd7Aw1+AIWwd+MURXUeXhwDw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@13.5.9':
+    resolution: {integrity: sha512-DwdeJqP7v8wmoyTWPbPVodTwCybBZa02xjSJ6YQFIFZFZ7dFgrieKW4Eo0GoIcOJq5+JxkQyejmI+8zwDp3pwA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@13.5.9':
+    resolution: {integrity: sha512-wdQsKsIsGSNdFojvjW3Ozrh8Q00+GqL3wTaMjDkQxVtRbAqfFBtrLPO0IuWChVUP2UeuQcHpVeUvu0YgOP00+g==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@13.5.9':
+    resolution: {integrity: sha512-6VpS+bodQqzOeCwGxoimlRoosiWlSc0C224I7SQWJZoyJuT1ChNCo+45QQH+/GtbR/s7nhaUqmiHdzZC9TXnXA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@13.5.9':
+    resolution: {integrity: sha512-XxG3yj61WDd28NA8gFASIR+2viQaYZEFQagEodhI/R49gXWnYhiflTeeEmCn7Vgnxa/OfK81h1gvhUZ66lozpw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@13.5.9':
+    resolution: {integrity: sha512-/dnscWqfO3+U8asd+Fc6dwL2l9AZDl7eKtPNKW8mKLh4Y4wOpjJiamhe8Dx+D+Oq0GYVjuW0WwjIxYWVozt2bA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@13.5.9':
+    resolution: {integrity: sha512-T/iPnyurOK5a4HRUcxAlss8uzoEf5h9tkd+W2dSWAfzxv8WLKlUgbfk+DH43JY3Gc2xK5URLuXrxDZ2mGfk/jw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-ia32-msvc@13.5.9':
+    resolution: {integrity: sha512-BLiPKJomaPrTAb7ykjA0LPcuuNMLDVK177Z1xe0nAem33+9FIayU4k/OWrtSn9SAJW/U60+1hoey5z+KCHdRLQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@13.5.9':
+    resolution: {integrity: sha512-/72/dZfjXXNY/u+n8gqZDjI6rxKMpYsgBBYNZKWOQw0BpBF7WCnPflRy3ZtvQ2+IYI3ZH2bPyj7K+6a6wNk90Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
+
+  '@swc/helpers@0.5.2':
+    resolution: {integrity: sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==}
+
+  busboy@1.6.0:
+    resolution: {integrity: sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==}
+    engines: {node: '>=10.16.0'}
+
+  caniuse-lite@1.0.30001741:
+    resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cookie@0.5.0:
+    resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
+    engines: {node: '>= 0.6'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jose@4.15.9:
+    resolution: {integrity: sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  next-auth@4.21.1:
+    resolution: {integrity: sha512-NYkU4jAPSVxWhCblE8dDFAnKM7kOoO/QEobQ0RoEVP9Wox99A3PKHwOAsWhSg8ahJG/iKIWk2Bo1xHvsS4R39Q==}
+    peerDependencies:
+      next: ^12.2.5 || ^13
+      nodemailer: ^6.6.5
+      react: ^17.0.2 || ^18
+      react-dom: ^17.0.2 || ^18
+    peerDependenciesMeta:
+      nodemailer:
+        optional: true
+
+  next@13.5.11:
+    resolution: {integrity: sha512-WUPJ6WbAX9tdC86kGTu92qkrRdgRqVrY++nwM+shmWQwmyxt4zhZfR59moXSI4N8GDYCBY3lIAqhzjDd4rTC8Q==}
+    engines: {node: '>=16.14.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      sass:
+        optional: true
+
+  oauth@0.9.15:
+    resolution: {integrity: sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==}
+
+  object-hash@2.2.0:
+    resolution: {integrity: sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==}
+    engines: {node: '>= 6'}
+
+  oidc-token-hash@5.1.1:
+    resolution: {integrity: sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==}
+    engines: {node: ^10.13.0 || >=12.0.0}
+
+  openid-client@5.7.1:
+    resolution: {integrity: sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  preact-render-to-string@5.2.6:
+    resolution: {integrity: sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.27.1:
+    resolution: {integrity: sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==}
+
+  pretty-format@3.8.0:
+    resolution: {integrity: sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==}
+
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
+  react@18.3.1:
+    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+    engines: {node: '>=0.10.0'}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  streamsearch@1.1.0:
+    resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
+    engines: {node: '>=10.0.0'}
+
+  styled-jsx@5.1.1:
+    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uuid@8.3.2:
+    resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    hasBin: true
+
+  watchpack@2.4.0:
+    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
+    engines: {node: '>=10.13.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+snapshots:
+
+  '@babel/runtime@7.28.4': {}
+
+  '@next/env@13.5.11': {}
+
+  '@next/swc-darwin-arm64@13.5.9':
+    optional: true
+
+  '@next/swc-darwin-x64@13.5.9':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@13.5.9':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@13.5.9':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@13.5.9':
+    optional: true
+
+  '@next/swc-linux-x64-musl@13.5.9':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@13.5.9':
+    optional: true
+
+  '@next/swc-win32-ia32-msvc@13.5.9':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@13.5.9':
+    optional: true
+
+  '@panva/hkdf@1.2.1': {}
+
+  '@swc/helpers@0.5.2':
+    dependencies:
+      tslib: 2.8.1
+
+  busboy@1.6.0:
+    dependencies:
+      streamsearch: 1.1.0
+
+  caniuse-lite@1.0.30001741: {}
+
+  client-only@0.0.1: {}
+
+  cookie@0.5.0: {}
+
+  glob-to-regexp@0.4.1: {}
+
+  graceful-fs@4.2.11: {}
+
+  jose@4.15.9: {}
+
+  js-tokens@4.0.0: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  nanoid@3.3.11: {}
+
+  next-auth@4.21.1(next@13.5.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@panva/hkdf': 1.2.1
+      cookie: 0.5.0
+      jose: 4.15.9
+      next: 13.5.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      oauth: 0.9.15
+      openid-client: 5.7.1
+      preact: 10.27.1
+      preact-render-to-string: 5.2.6(preact@10.27.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      uuid: 8.3.2
+
+  next@13.5.11(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@next/env': 13.5.11
+      '@swc/helpers': 0.5.2
+      busboy: 1.6.0
+      caniuse-lite: 1.0.30001741
+      postcss: 8.4.31
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
+      watchpack: 2.4.0
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 13.5.9
+      '@next/swc-darwin-x64': 13.5.9
+      '@next/swc-linux-arm64-gnu': 13.5.9
+      '@next/swc-linux-arm64-musl': 13.5.9
+      '@next/swc-linux-x64-gnu': 13.5.9
+      '@next/swc-linux-x64-musl': 13.5.9
+      '@next/swc-win32-arm64-msvc': 13.5.9
+      '@next/swc-win32-ia32-msvc': 13.5.9
+      '@next/swc-win32-x64-msvc': 13.5.9
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  oauth@0.9.15: {}
+
+  object-hash@2.2.0: {}
+
+  oidc-token-hash@5.1.1: {}
+
+  openid-client@5.7.1:
+    dependencies:
+      jose: 4.15.9
+      lru-cache: 6.0.0
+      object-hash: 2.2.0
+      oidc-token-hash: 5.1.1
+
+  picocolors@1.1.1: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  preact-render-to-string@5.2.6(preact@10.27.1):
+    dependencies:
+      preact: 10.27.1
+      pretty-format: 3.8.0
+
+  preact@10.27.1: {}
+
+  pretty-format@3.8.0: {}
+
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
+  react@18.3.1:
+    dependencies:
+      loose-envify: 1.4.0
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
+
+  source-map-js@1.2.1: {}
+
+  streamsearch@1.1.0: {}
+
+  styled-jsx@5.1.1(react@18.3.1):
+    dependencies:
+      client-only: 0.0.1
+      react: 18.3.1
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.2: {}
+
+  uuid@8.3.2: {}
+
+  watchpack@2.4.0:
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+
+  yallist@4.0.0: {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,128 @@
+import type { AuthOptions } from 'next-auth'
+
+/**
+ * This function had to be added because the `next-auth/prisma-adapter` adapter has an import from `@prisma/client`.
+ * However, since our client is located under `~~/prisma/client`, it could not be found and this leads to an error.
+ *
+ * The code below was taken from the next-auth repo. The types were added to have them available.
+ * Next-Auth@4.21.1: https://github.com/nextauthjs/next-auth/blob/next-auth%404.21.1/packages/adapter-prisma/src/index.ts
+ */
+type Adapter = Exclude<AuthOptions['adapter'], undefined>
+type AdapterAccount = Parameters<Adapter['linkAccount']>[0]
+type AdapterSession = Awaited<ReturnType<Adapter['createSession']>>
+type AdapterUser = Awaited<ReturnType<Adapter['createUser']>>
+type VerificationToken = Exclude<Awaited<ReturnType<Exclude<Adapter['useVerificationToken'], undefined>>>, null>
+
+interface PrismaClient {
+  account: {
+    create: (args: Data<AdapterAccount>) => Promise<Omit<AdapterAccount, 'type'> & { type: string }>
+    findUnique: (args: { where: PrismaAccountWhereUniqueInput, select: { user: true } }) => Promise<{ user: AdapterUser } | null>
+    delete: (args: Where<PrismaAccountWhereUniqueInput>) => void
+  }
+
+  session: {
+    create: (args: Data<AdapterSession>) => Promise<AdapterSession>
+    findUnique: (args: { where: PrismaSessionWhereUniqueInput, include: { user: true } }) => Promise<AdapterSession & { user: AdapterUser } | null>
+    update: (args: WhereAndData<PrismaSessionWhereUniqueInput, Partial<AdapterSession> & Pick<AdapterSession, 'sessionToken'>>) => Promise<AdapterSession>
+    delete: (args: Where<PrismaSessionWhereUniqueInput>) => Promise<AdapterSession>
+  }
+
+  user: {
+    create: (args: Data<Omit<AdapterUser, 'id'>>) => Promise<AdapterUser>
+    findUnique: (args: Where<PrismaUserWhereUniqueInput>) => Promise<AdapterUser | null>
+    update: (args: WhereAndData<PrismaUserWhereUniqueInput, Partial<AdapterUser>>) => Promise<AdapterUser>
+    delete: (args: Where<PrismaUserWhereUniqueInput>) => Promise<AdapterUser>
+  }
+
+  verificationToken: {
+    create: (args: Data<VerificationToken>) => Promise<VerificationToken>
+    delete: (args: Where<{ identifier_token: Pick<VerificationToken, 'identifier' | 'token'> }>) => Promise<VerificationToken>
+  }
+}
+
+interface Where<T> {
+  where: T
+}
+
+interface Data<D> {
+  data: D
+}
+
+interface WhereAndData<W, D> extends Where<W>, Data<D> {}
+
+type PrismaUserWhereUniqueInput = { id: string } | { email: string }
+interface PrismaAccountWhereUniqueInput { provider_providerAccountId: Pick<AdapterAccount, 'provider' | 'providerAccountId'> }
+interface PrismaSessionWhereUniqueInput { sessionToken: string }
+
+interface PrismaClientKnownRequestError {
+  code: string
+}
+
+export function PrismaAdapter(p: PrismaClient): Adapter {
+  return {
+    createUser: data => p.user.create({ data }),
+    getUser: id => p.user.findUnique({ where: { id } }),
+    getUserByEmail: email => p.user.findUnique({ where: { email } }),
+    async getUserByAccount(provider_providerAccountId) {
+      const account = await p.account.findUnique({
+        where: { provider_providerAccountId },
+        select: { user: true },
+      })
+      return account?.user ?? null
+    },
+    updateUser: ({ id, ...data }) => p.user.update({ where: { id }, data }),
+    deleteUser: id => p.user.delete({ where: { id } }),
+    linkAccount: data =>
+      p.account.create({ data }) as unknown as AdapterAccount,
+    unlinkAccount: provider_providerAccountId =>
+      p.account.delete({
+        where: { provider_providerAccountId },
+      }) as unknown as AdapterAccount,
+    async getSessionAndUser(sessionToken) {
+      const userAndSession = await p.session.findUnique({
+        where: { sessionToken },
+        include: { user: true },
+      })
+      if (!userAndSession) {
+        return null
+      }
+      const { user, ...session } = userAndSession
+      return { user, session }
+    },
+    createSession: data => p.session.create({ data }),
+    updateSession: data =>
+      p.session.update({ where: { sessionToken: data.sessionToken }, data }),
+    deleteSession: sessionToken =>
+      p.session.delete({ where: { sessionToken } }),
+    async createVerificationToken(data) {
+      const verificationToken = await p.verificationToken.create({ data })
+      // @ts-expect-errors // MongoDB needs an ID, but we don't
+      if (verificationToken.id) {
+        // @ts-expect-errors // MongoDB needs an ID, but we don't
+        delete verificationToken.id
+      }
+      return verificationToken
+    },
+    async useVerificationToken(identifier_token) {
+      try {
+        const verificationToken = await p.verificationToken.delete({
+          where: { identifier_token },
+        })
+        // @ts-expect-errors // MongoDB needs an ID, but we don't
+        if (verificationToken.id) {
+          // @ts-expect-errors // MongoDB needs an ID, but we don't
+          delete verificationToken.id
+        }
+        return verificationToken
+      }
+      catch (error) {
+        // If token already used/deleted, just return null
+        // https://www.prisma.io/docs/reference/api-reference/error-reference#p2025
+        if ((error as PrismaClientKnownRequestError).code === 'P2025') {
+          return null
+        }
+        throw error
+      }
+    },
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,10 @@ import type { AuthOptions } from 'next-auth'
 
 /**
  * This function had to be added because the `next-auth/prisma-adapter` adapter has an import from `@prisma/client`.
- * However, since our client is located under `~~/prisma/client`, it could not be found and this leads to an error.
+ * However, since the client can be located anywhere (e.g. in `~/prisma/client`),
+ * it can not be found in `@prisma/client` and this leads to an error with the official adapter.
  *
- * The code below was taken from the next-auth repo. The types were added to have them available.
+ * The code below was taken from the next-auth repo. The types were added to not depend on Prisma types at all.
  * Next-Auth@4.21.1: https://github.com/nextauthjs/next-auth/blob/next-auth%404.21.1/packages/adapter-prisma/src/index.ts
  */
 type Adapter = Exclude<AuthOptions['adapter'], undefined>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "NodeNext",               // supports both ESM & CJS interop
+    "declaration": true,                // emit .d.ts files
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Closes N/A

This adds the initial implementation for supporting Prisma 6 inside `next-auth@4.21.1`

Checklist:
- [ ] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [ ] manually checked my feature / checking not applicable
- [ ] wrote tests / testing not applicable
- [ ] attached screenshots / screenshot not applicable
